### PR TITLE
Fix matching barrel fluids without registered containers

### DIFF
--- a/src/main/java/net/dries007/tfcnei/recipeHandlers/BarrelRecipeHandler.java
+++ b/src/main/java/net/dries007/tfcnei/recipeHandlers/BarrelRecipeHandler.java
@@ -137,7 +137,7 @@ public class BarrelRecipeHandler extends TemplateRecipeHandler
             ItemStack outItem = recipe.getRecipeOutIS();
             FluidStack outFluid = recipe.getRecipeOutFluid();
 
-            if ((outItem != null && Helper.areItemStacksEqual(result, outItem)) || (outFluid != null && outFluid.isFluidEqual(result)))
+            if ((outItem != null && Helper.areItemStacksEqual(result, outItem)) || (outFluid != null && Helper.isFluidEqual(outFluid, result)))
             {
                 arecipes.add(new CachedBarrelRecipe(recipe));
             }
@@ -147,13 +147,12 @@ public class BarrelRecipeHandler extends TemplateRecipeHandler
     @Override
     public void loadUsageRecipes(ItemStack ingredient)
     {
-        FluidStack fluidStack = getFluidForFilledItem(ingredient);
         for (BarrelRecipe recipe : recipeList)
         {
             ItemStack inItem = recipe.getInItem();
             FluidStack inFluid = recipe.getInFluid();
 
-            if ((inItem != null && Helper.areItemStacksEqual(inItem, ingredient)) || (inFluid != null && inFluid.isFluidEqual(fluidStack)))
+            if ((inItem != null && Helper.areItemStacksEqual(inItem, ingredient)) || (inFluid != null && Helper.isFluidEqual(inFluid, ingredient)))
             {
                 arecipes.add(new CachedBarrelRecipe(recipe));
             }

--- a/src/main/java/net/dries007/tfcnei/util/Helper.java
+++ b/src/main/java/net/dries007/tfcnei/util/Helper.java
@@ -37,6 +37,7 @@
 package net.dries007.tfcnei.util;
 
 import cpw.mods.fml.relauncher.ReflectionHelper;
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -46,6 +47,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidContainerRegistry;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 import org.lwjgl.opengl.GL11;
@@ -144,4 +146,17 @@ public class Helper
     {
         return input == target || OreDictionary.itemMatches(target, input, false);
     }
+
+    public static boolean isFluidEqual(FluidStack fluidStack, ItemStack itemStack) {
+        // Try to reconstruct fluid stack from sponge block
+        if (Block.getBlockFromItem(itemStack.getItem()) == Blocks.sponge && itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey("FLUID")) {
+            String fluidName = itemStack.getTagCompound().getString("FLUID");
+            FluidStack other = FluidRegistry.getFluidStack(fluidName, itemStack.stackSize * FluidContainerRegistry.BUCKET_VOLUME);
+            return other != null && other.isFluidEqual(fluidStack);
+        }
+
+        // Try to match fluid with registered containers
+        return fluidStack.isFluidEqual(itemStack);
+    }
+
 }


### PR DESCRIPTION
Made some changes to TFC+NEI that allow listing Barrel recipes involving fluids that do not have a registered container.